### PR TITLE
Fix AStyle formatting and bug in CAN transport

### DIFF
--- a/hal/transport/CAN/MyTransportCAN.cpp
+++ b/hal/transport/CAN/MyTransportCAN.cpp
@@ -7,7 +7,7 @@
 #define CAN_DEBUG(x,...)	//!< DEBUG null
 #endif
 MCP_CAN CAN0(CAN_CS);
-bool canInitialized=false;
+bool canInitialized = false;
 
 //input buffer for raw data (from library).
 long unsigned int rxId;
@@ -16,7 +16,7 @@ unsigned char rxBuf[8];
 unsigned char _nodeId;
 
 //message id updated for every outgoing mesage
-uint8_t message_id =0;
+uint8_t message_id = 0;
 
 //buffer element
 typedef struct {
@@ -163,10 +163,9 @@ long unsigned int _buildHeader(uint8_t messageId, uint8_t totalPartCount, uint8_
 	header += toAddress;//set destination address
 	header = header << 8;
 	header += fromAddress;//set source address
-	CAN_DEBUG(PSTR("CAN:SND:CANH=%" PRIu32 ",ID=%" PRIu8
-	               ",TOTAL=%" PRIu8 ",CURR=%" PRIu8 ",TO=%" PRIu8 ",FROM=%" PRIu8 "\n"), header, messageId,
-	          totalPartCount,
-	          currentPartNumber, toAddress, fromAddress);
+	CAN_DEBUG(PSTR("CAN:SND:CANH=%" PRIu32 ",ID=%" PRIu8 ",TOTAL=%" PRIu8 ",CURR=%" PRIu8 ",TO=%" PRIu8
+	               ",FROM=%" PRIu8 "\n"),
+	          header, messageId, totalPartCount, currentPartNumber, toAddress, fromAddress);
 	return header;
 }
 
@@ -203,9 +202,8 @@ bool transportSend(const uint8_t to, const void *data, const uint8_t len, const 
 		}
 
 		CAN_DEBUG(PSTR("CAN:SND:LN=%" PRIu8 ",DTA0=%" PRIu8 ",DTA1=%" PRIu8 ",DTA2=%" PRIu8 ",DTA3=%" PRIu8
-		               ",DTA4=%" PRIu8 ",DTA5=%" PRIu8 ",DTA6=%" PRIu8 ",DTA7=%" PRIu8 "\n"), partLen, buff[0],
-		          buff[1],
-		          buff[2], buff[3], buff[4], buff[5], buff[6], buff[7]);
+		               ",DTA4=%" PRIu8 ",DTA5=%" PRIu8 ",DTA6=%" PRIu8 ",DTA7=%" PRIu8 "\n"),
+		          partLen, buff[0], buff[1], buff[2], buff[3], buff[4], buff[5], buff[6], buff[7]);
 
 		byte sndStat = CAN0.sendMsgBuf(_buildHeader(message_id, noOfFrames, currentFrame, to, _nodeId),
 		                               partLen, buff);
@@ -230,15 +228,12 @@ bool transportDataAvailable(void)
 		long unsigned int messageId = (rxId & 0x07000000) >> 24;
 #if defined(MY_DEBUG_VERBOSE_CAN)
 		long unsigned int to = (rxId & 0x0000FF00) >> 8;
-		CAN_DEBUG(PSTR("CAN:RCV:CANH=%" PRIu32 ",ID=%" PRIu32 {
-			",TOTAL=%"
-		} PRIu32 ",CURR=%" PRIu32 ",TO=%" PRIu32 ",FROM=%" PRIu32 "\n"), rxId, messageId,
-		totalPartCount,
-		currentPart, to, from);
+		CAN_DEBUG(PSTR("CAN:RCV:CANH=%" PRIu32 ",ID=%" PRIu32 ",TOTAL=%" PRIu32 ",CURR=%" PRIu32 ",TO=%"
+		               PRIu32 ",FROM=%" PRIu32 "\n"),
+		          rxId, messageId, totalPartCount, currentPart, to, from);
 		CAN_DEBUG(PSTR("CAN:RCV:LN=%" PRIu8 ",DTA0=%" PRIu8 ",DTA1=%" PRIu8 ",DTA2=%" PRIu8 ",DTA3=%" PRIu8
-		               ",DTA4=%" PRIu8 ",DTA5=%" PRIu8 ",DTA6=%" PRIu8 ",DTA7=%" PRIu8 "\n"), len, rxBuf[0],
-		          rxBuf[1],
-		          rxBuf[2], rxBuf[3], rxBuf[4], rxBuf[5], rxBuf[6], rxBuf[7]);
+		               ",DTA4=%" PRIu8 ",DTA5=%" PRIu8 ",DTA6=%" PRIu8 ",DTA7=%" PRIu8 "\n"),
+		          len, rxBuf[0], rxBuf[1], rxBuf[2], rxBuf[3], rxBuf[4], rxBuf[5], rxBuf[6], rxBuf[7]);
 #endif
 		uint8_t slot;
 		if (currentPart == 0) {

--- a/tests/Arduino/sketches/can_transport/can_transport.ino
+++ b/tests/Arduino/sketches/can_transport/can_transport.ino
@@ -1,0 +1,33 @@
+/*
+ * The MySensors Arduino library handles the wireless radio link and protocol
+ * between your home built sensors/actuators and HA controller of choice.
+ * The sensors forms a self healing radio network with optional repeaters. Each
+ * repeater and gateway builds a routing tables in EEPROM which keeps track of the
+ * network topology allowing messages to be routed to nodes.
+ *
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2022 Sensnology AB
+ * Full contributor list: https://github.com/mysensors/MySensors/graphs/contributors
+ *
+ * Documentation: http://www.mysensors.org
+ * Support Forum: http://forum.mysensors.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ *******************************
+ */
+#define MY_DEBUG
+#define MY_CAN
+#define CAN_CS (10u)
+#define MY_DEBUG_VERBOSE_CAN
+#include <MySensors.h>
+
+void setup()
+{
+}
+
+void loop()
+{
+}


### PR DESCRIPTION
@AdamSlowik Looks like the AStyle formatter introduced a bug by adding curly braces into one of your CAN_DEBUG lines.
This bug only crashes on build when MY_DEBUG_VERBOSE_CAN is defined.

Shame on AStyle! Also I added a test sketch for the Jenkins CI. Hopefully Jenkins CI will catch now such bugs.

- Fix AStyle formatting and bug in CAN transport
- Add test sketch can_transport for Jenkins CI

If you agree, then please merge this PR before PR #1.